### PR TITLE
Improvements to output formatting

### DIFF
--- a/gadget_forms/quag_crib_drag.html
+++ b/gadget_forms/quag_crib_drag.html
@@ -13,6 +13,7 @@ var crib = [];
 var period, quag_array, inv_array, out_str;
 var numb_cribs;
 var start_positions = [];
+var match_count;
     
 function setup_cipher() {
 	var i,j,state,cnt,c, data,n1,n;
@@ -72,6 +73,7 @@ function do_calc(){
     }
     document.getElementById('output_area').value = "Working...";
     setTimeout(function() {
+        match_count = 0;
         out_str = "period "+period+"\n";
         construct_crib(0);
         document.getElementById('output_area').value = out_str;
@@ -137,10 +139,13 @@ function construct_crib( stage){
 		if ( stage < numb_cribs) construct_crib(stage+1);
 		else {
             var pos_offset = document.getElementById('use_pos_ref').checked ? 1 : 0;
+            if (match_count > 0)
+                out_str += "\n==================================================\n";
             if (numb_cribs == 0)
                 out_str += "\nOK at "+(start_pos+pos_offset)+"\n";
             else
                 out_str += "\nOK at "+start_positions.slice(0, numb_cribs+1).map(function(p){return p+pos_offset;}).join(", ")+"\n";
+            match_count++;
             index = 0;
             cnt = 0;
             for (i=0;i<buf_len;i++){
@@ -157,8 +162,40 @@ function construct_crib( stage){
                 }
             }
             out_str += '\n';
+            if (document.getElementById('show_placements').checked) {
+                var pairs = [];
+                for (var si=0; si<=numb_cribs; si++)
+                    pairs.push([si, start_positions[si]]);
+                pairs.sort(function(a,b){ return a[1]-b[1]; });
+                for (var pi2=0; pi2<pairs.length; pi2++) {
+                    var si = pairs[pi2][0];
+                    var sp = pairs[pi2][1];
+                    var crib_text = '';
+                    for (var ci=0; ci<crib[si].length; ci++)
+                        crib_text += alpha[crib[si][ci]];
+                    var ct_text = '';
+                    for (var ci=0; ci<crib[si].length; ci++)
+                        ct_text += upperC[buffer[sp+ci]];
+                    out_str += '\nCrib: ' + crib_text + '\n';
+                    out_str += 'Ct:   ' + ct_text + ' (' + (sp+pos_offset) + ')\n';
+                }
+            }
+            if (document.getElementById('show_matrix').checked) {
+                var wide = (period > 9);
+                out_str += "\n" + (wide ? " 0" : "0") + "  ABCDEFGHIJKLMNOPQRSTUVWXYZ\n";
+                for (var ai=0; ai<period; ai++) {
+                    var rowNum = String(ai+1);
+                    if (wide && rowNum.length < 2) rowNum = " " + rowNum;
+                    out_str += rowNum + "  ";
+                    for (var pi=0; pi<26; pi++) {
+                        var ct = inv_array[stage][ai][pi];
+                        out_str += (ct == -1) ? '.' : upperC[ct];
+                    }
+                    out_str += '\n';
+                }
+            }
         }
-        
+
 	}
 }
 
@@ -177,7 +214,13 @@ Crib (if multiple crib strings put them on separate lines):<br>
 </textarea><br>
 <br>
 <input type="checkbox" id="use_pos_ref" onchange="document.getElementById('pos_ref_label').innerText = this.checked ? 'Output (positions start at 1):' : 'Output (positions start at 0):';">
-Use Position References<br>
+Use Position References
+&nbsp;&nbsp;&nbsp;
+<input type="checkbox" id="show_placements">
+Show Placements
+&nbsp;&nbsp;&nbsp;
+<input type="checkbox" id="show_matrix">
+Show Reconstruction Matrix<br>
 <br>
 <input type="button" value="Crib Drag" onclick=do_calc();>
 &nbsp  &nbsp &nbsp Period:

--- a/gadget_forms/quag_crib_drag.html
+++ b/gadget_forms/quag_crib_drag.html
@@ -12,6 +12,7 @@ var crib = [];
 
 var period, quag_array, inv_array, out_str;
 var numb_cribs;
+var start_positions = [];
     
 function setup_cipher() {
 	var i,j,state,cnt,c, data,n1,n;
@@ -69,10 +70,13 @@ function do_calc(){
         alert("No period entered!");
         return;
     }
-    out_str = "period "+period+" ";   	    
-    construct_crib(0);
-    document.getElementById('output_area').value = out_str;        
-    
+    document.getElementById('output_area').value = "Working...";
+    setTimeout(function() {
+        out_str = "period "+period+"\n";
+        construct_crib(0);
+        document.getElementById('output_area').value = out_str;
+    }, 50);
+
 }
 
 function construct_crib( stage){
@@ -108,6 +112,7 @@ function construct_crib( stage){
                 }
 			}
 		}
+        start_positions[stage] = start_pos;
         index = start_pos % period;
         flag = 0;
         for (j=0;j<crib[stage].length;j++) {
@@ -132,9 +137,9 @@ function construct_crib( stage){
 		if ( stage < numb_cribs) construct_crib(stage+1);
 		else {
             if (numb_cribs == 0)
-                out_str += "OK at "+start_pos+"\n";
+                out_str += "\nOK at "+start_pos+"\n";
             else
-                out_str += "OK at \n";
+                out_str += "\nOK at "+start_positions.slice(0, numb_cribs+1).join(", ")+"\n";
             index = 0;
             cnt = 0;
             for (i=0;i<buf_len;i++){

--- a/gadget_forms/quag_crib_drag.html
+++ b/gadget_forms/quag_crib_drag.html
@@ -170,7 +170,8 @@ Directions: Type or paste in ciphertext and crib (or cribs). Set period. Click C
 Ciphertext:<br>
 <textarea id="cipher_area" rows = 5 cols=90 spellcheck="false" >
 </textarea><br>
-crib (if multiple crib strings put them on separate lines):<br>
+<br>
+Crib (if multiple crib strings put them on separate lines):<br>
 <textarea id="crib_area" rows = 5 cols=90 >
 </textarea><br>
 <br>

--- a/gadget_forms/quag_crib_drag.html
+++ b/gadget_forms/quag_crib_drag.html
@@ -146,22 +146,28 @@ function construct_crib( stage){
             else
                 out_str += "\nOK at "+start_positions.slice(0, numb_cribs+1).map(function(p){return p+pos_offset;}).join(", ")+"\n";
             match_count++;
+            var pt_blocks = [], ct_blocks = [];
+            var pt_block = '', ct_block = '';
             index = 0;
-            cnt = 0;
             for (i=0;i<buf_len;i++){
                 c = buffer[i];
                 c1 = quag_array[stage][index][c];
-                if (c1 == -1)
-                    out_str += '-';
-                else
-                    out_str += alpha[c1];
+                pt_block += (c1 == -1) ? '-' : alpha[c1];
+                ct_block += upperC[c];
                 index = (index+1) % period;
-                if ( ++cnt == 50){
-                    cnt = 0;
-                    out_str += '\n';
+                if (pt_block.length == period || i == buf_len-1){
+                    pt_blocks.push(pt_block);
+                    ct_blocks.push(ct_block);
+                    pt_block = '';
+                    ct_block = '';
                 }
             }
-            out_str += '\n';
+            var blocks_per_line = Math.max(1, Math.floor(51 / (period + 1)));
+            for (var b=0; b<pt_blocks.length; b+=blocks_per_line){
+                var last_group = (b + blocks_per_line >= pt_blocks.length);
+                out_str += pt_blocks.slice(b, b+blocks_per_line).join(' ') + '\n';
+                out_str += ct_blocks.slice(b, b+blocks_per_line).join(' ') + (last_group ? '\n' : '\n\n');
+            }
             if (document.getElementById('show_placements').checked) {
                 var pairs = [];
                 for (var si=0; si<=numb_cribs; si++)

--- a/gadget_forms/quag_crib_drag.html
+++ b/gadget_forms/quag_crib_drag.html
@@ -136,10 +136,11 @@ function construct_crib( stage){
         if ( flag) continue;
 		if ( stage < numb_cribs) construct_crib(stage+1);
 		else {
+            var pos_offset = document.getElementById('use_pos_ref').checked ? 1 : 0;
             if (numb_cribs == 0)
-                out_str += "\nOK at "+start_pos+"\n";
+                out_str += "\nOK at "+(start_pos+pos_offset)+"\n";
             else
-                out_str += "\nOK at "+start_positions.slice(0, numb_cribs+1).join(", ")+"\n";
+                out_str += "\nOK at "+start_positions.slice(0, numb_cribs+1).map(function(p){return p+pos_offset;}).join(", ")+"\n";
             index = 0;
             cnt = 0;
             for (i=0;i<buf_len;i++){
@@ -175,11 +176,14 @@ Crib (if multiple crib strings put them on separate lines):<br>
 <textarea id="crib_area" rows = 5 cols=90 >
 </textarea><br>
 <br>
+<input type="checkbox" id="use_pos_ref" onchange="document.getElementById('pos_ref_label').innerText = this.checked ? 'Output (positions start at 1):' : 'Output (positions start at 0):';">
+Use Position References<br>
+<br>
 <input type="button" value="Crib Drag" onclick=do_calc();>
-&nbsp  &nbsp &nbsp Period: 
+&nbsp  &nbsp &nbsp Period:
 <input type = text id="per"  size = 2 >
 <br><br>
-Output (positions start at 0):<br>
+<span id="pos_ref_label">Output (positions start at 0):</span><br>
 <textarea id="output_area" rows=12 cols=90>
 </textarea>
 


### PR DESCRIPTION
    Fix quag_crib_drag.html: multi-crib positions, formatting, and UI responsiveness

    - Fix missing position numbers in "OK at" output when multiple cribs are used;
      track each stage's start_pos in start_positions[] and display all on match
    - Insert a blank line before each "OK at" block for readability
    - Add newline after "period N" header line
    - Clear output area and show "Working..." on button click, using setTimeout(50)
      to ensure the browser repaints before computation begins
    - Checkbox to choose between 0-based offset and 1-based position
    - Added 'Use Position References' checkbox, choose between 0-based offset and 1-based position
    - Checkbox to display crib placements
    - Checkbox to display reconstruction matrix
    - Displays the crib placement offset/position value
    - Generated plaintext is (a) parsed in blocks of <period>, and (b) paired with the corresponding ciphertext below it.
